### PR TITLE
fix: regenerate integration extension everytime

### DIFF
--- a/lib/api-gtw.js
+++ b/lib/api-gtw.js
@@ -38,10 +38,7 @@ module.exports = class ApiGateway {
       restApiId: id,
       exportType: options.exportApi || 'oas30',
       stageName: options.stageName || 'default',
-      accepts: 'application/json',
-      parameters: {
-        extensions: 'integrations'
-      }
+      accepts: 'application/json'
     }
 
     return await this.gtw.getExport(params).promise();


### PR DESCRIPTION
La partie forward de header se trouvant dans l'extension amazon, elle n'était pas modifiée dans le cas où on modifie/ajoute un header dans une des APIs, causant un bug lors du déploiement.
Ici, on recrée donc l'extension complètement à chaque fois

=> https://ethias.atlassian.net/browse/FAPI-1130